### PR TITLE
Add functionality to enable swapfile [WIP]

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,6 +32,7 @@ Vagrant.configure("2") do |config|
                 { option: "upload_max_filesize", value: "100M" },
                 { option: "post_max_size", value: "100M" }
             ],
+            install_swapfile: "yes"
             install_gems: ["compass", "zurb-foundation"],
             install_db: "yes",
             install_ohmyzsh: "yes",

--- a/provision.yml
+++ b/provision.yml
@@ -7,6 +7,7 @@
     dbpasswd: "password"
     databases: []
     sites: []
+    install_swapfile: "no"
     install_db: "no"
     install_web: "no"
     install_ohmyzsh: "no"
@@ -23,6 +24,8 @@
     scala_activator_version: "1.2.10"
   tasks:
     - include: tasks/system.yml
+    - include: tasks/swapfile.yml
+      when: install_swapfile == "yes"
     - include: tasks/ohmyzsh.yml
       when: install_ohmyzsh == "yes"
     - include: tasks/mysql.yml

--- a/tasks/swapfile.yml
+++ b/tasks/swapfile.yml
@@ -1,0 +1,50 @@
+#
+# From: http://stackoverflow.com/questions/24765930/add-swap-memory-with-ansible
+#
+- name: Create swap file
+  command: dd if=/dev/zero of={{ swap_file_path }} bs=1024 count={{ swap_file_size_kb }}k
+           creates="{{ swap_file_path }}"
+  tags:
+    - swap.file.create
+
+
+- name: Change swap file permissions
+  file: path="{{ swap_file_path }}"
+        owner=root
+        group=root
+        mode=0600
+  tags:
+    - swap.file.permissions
+
+
+- name: "Check swap file type"
+  command: file {{ swap_file_path }}
+  register: swapfile
+  tags:
+    - swap.file.mkswap
+
+
+- name: Make swap file
+  command: "sudo mkswap {{ swap_file_path }}"
+  when: swapfile.stdout.find('swap file') == -1
+  tags:
+    - swap.file.mkswap
+
+
+- name: Write swap entry in fstab
+  mount: name=none
+         src={{ swap_file_path }}
+         fstype=swap
+         opts=sw
+         passno=0
+         dump=0
+         state=present
+  tags:
+    - swap.fstab
+
+
+- name: Mount swap
+  command: "swapon {{ swap_file_path }}"
+  when: ansible_swaptotal_mb < 1
+  tags:
+    - swap.file.swapon


### PR DESCRIPTION
Disclaimer, my ansible skills are near to none, trying to figure out if the `swap_file_path` and `swap_file_size_kb` should be in `provision.yml`.

Preferably, you'd want `swap_file_path` to reside in like `/tmp/swap.bin` or something, but able to be overridden. Same goes for `swap_file_size_kb`, which can default to 2GB for example, but able to be overridden.

Any feedback, tips, hints?