### PR TITLE
Missing provision variable

### DIFF
--- a/provision.yml
+++ b/provision.yml
@@ -7,6 +7,7 @@
     dbpasswd: "password"
     databases: []
     sites: []
+    php_configs: []
     install_db: "no"
     install_web: "no"
     install_ohmyzsh: "no"


### PR DESCRIPTION
Ansible would not provision without the variable in the extra vars.