### PR TITLE
Consecutive provisioning runs fail when specified database user is root

### DIFF
--- a/files/.my.cnf
+++ b/files/.my.cnf
@@ -1,0 +1,3 @@
+[client]
+user={{dbuser}}
+password={{dbpasswd}}

--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -15,9 +15,12 @@
     - ::1
     - localhost
 
-- name: MySQL | Copy Config File
+- name: MySQL | Copy Server Config File
   template: src=../files/my.cnf dest=/etc/mysql/my.cnf owner={{ dbuser }} mode=0600
   notify: restart mysql
+
+- name: MySQL | Copy User Config File
+  template: src=../files/.my.cnf dest=/root/.my.cnf owner=root mode=0600
 
 - name: MySQL | Create Databases
   mysql_db: name={{ item }} state=present login_password={{ dbpasswd }} login_user={{ dbuser }}


### PR DESCRIPTION
When the box is provisioned multiple times (by calling vagrant provision after vagrant up, for instance), and the MySQL username is set to "root" and a password is specified, the provisioning runs will fail after the first run:

````
TASK: [MySQL | Create User] ***************************************************
failed: [default] => (item=%) => {"failed": true, "item": "%"}
msg: unable to connect to database, check login_user and login_password are correct or ~/.my.cnf has the credentials
failed: [default] => (item=127.0.0.1) => {"failed": true, "item": "127.0.0.1"}
msg: unable to connect to database, check login_user and login_password are correct or ~/.my.cnf has the credentials
failed: [default] => (item=::1) => {"failed": true, "item": "::1"}
msg: unable to connect to database, check login_user and login_password are correct or ~/.my.cnf has the credentials
failed: [default] => (item=localhost) => {"failed": true, "item": "localhost"}
msg: unable to connect to database, check login_user and login_password are correct or ~/.my.cnf has the credentials

FATAL: all hosts have already failed -- aborting
```

The reason for that is that on the first run, ansible can log into MySQL as root without a password, while after the second run the password has been changed and it can no longer log in to check if the MySQL user exists.

This PR makes sure that we add a .my.cnf file to root's home directory, containing the username and password specified in the vagrant file. This will make sure that ansible will use the correct username and password on consecutive runs.