### PR TITLE
Add symfony task to enable doctrine database creation on provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This virtual machine configuration is designed to have ONE application per machi
 - [Beanstalkd](http://kr.github.io/beanstalkd/) _(optional)_
 - [Redis](http://redis.io) _(optional)_
 - [R](http://r-project.org) _(optional)_
+- [Symfony](http://symfony.com/) _(optional)_
 - [Java](http://java.com) _(optional)_
 - [Typesafe Activator](http://scala-lang.org) _(optional)_
 - [EventStore](http://geteventstore.com) _(optional)_
@@ -56,6 +57,7 @@ install_javascript_build_system: "no"
 install_gems: []
 install_r: "no"
 r_packages: []
+symfony: "no"
 install_java: "no"
 install_typesafe_activator: "no"
 typesafe_activator_version: "1.2.10"

--- a/provision.yml
+++ b/provision.yml
@@ -27,6 +27,7 @@
     install_r: "no"
     php_configs: []
     r_packages: []
+    symfony: "no"
     install_java: "no"
     enable_swap: "no"
     swap_size_in_mb: 1024
@@ -62,6 +63,8 @@
     - include: tasks/ruby.yml
     - include: tasks/r.yml
       when: install_r == "yes"
+    - include: tasks/symfony.yml
+      when: symfony == "yes"
     - include: tasks/java.yml
       when: install_java == "yes"
     - include: tasks/swap.yml

--- a/tasks/symfony.yml
+++ b/tasks/symfony.yml
@@ -1,0 +1,5 @@
+---
+# Symfony
+
+- name: Symfony | Create Doctrine schema
+  shell: ./app/console doctrine:schema:create


### PR DESCRIPTION
When `symfony: "yes"` is being set, the symfony task is being included, and provisioning should create a doctrine database.