### PR TITLE
The PHP PPA specific to 5.6 is deprecated, use the new one

### DIFF
--- a/tasks/php-fpm.yml
+++ b/tasks/php-fpm.yml
@@ -2,7 +2,7 @@
 # PHP5-FPM
 
 - name: PHP-FPM | Install PHP5-FPM
-  apt: pkg=php5-fpm state=installed
+  apt: pkg=php5.6-fpm state=installed
 
 - name: PHP-FPM | Install Primary Configuration File
   template: src=../files/php-fpm.conf dest=/etc/php5/fpm/php-fpm.conf

--- a/tasks/php.yml
+++ b/tasks/php.yml
@@ -1,11 +1,11 @@
 ---
 # PHP
 
-- name: PHP | Install 5.6 PPA
-  apt_repository: repo='ppa:ondrej/php5-5.6' update_cache=yes
+- name: PHP | Install Ondrej PHP PPA
+  apt_repository: repo='ppa:ondrej/php' update_cache=yes
 
 - name: PHP | Install PHP
-  apt: pkg=php5 state=latest
+  apt: pkg=php5.6 state=latest
   tags: common
 
 - name: PHP | Install PHP Modules


### PR DESCRIPTION
It seems the `ondrej/php5-5.6` PPA is deprecated in favor of `ondrej/php`.
This new PPA contains multiple versions of PHP, so I've pinned it down to 5.6